### PR TITLE
Fix/20260510 ldap identity signin cheks

### DIFF
--- a/src/Skoruba.Duende.IdentityServer.Admin.EntityFramework.Shared/Entities/Identity/IUserWithDomain.cs
+++ b/src/Skoruba.Duende.IdentityServer.Admin.EntityFramework.Shared/Entities/Identity/IUserWithDomain.cs
@@ -1,0 +1,8 @@
+namespace Skoruba.Duende.IdentityServer.Admin.EntityFramework.Shared.Entities.Identity
+{
+    public interface IUserWithDomain
+    {
+        string UserDomain { get; set; }
+        string UserName { get; set; }
+    }
+}

--- a/src/Skoruba.Duende.IdentityServer.Admin.EntityFramework.Shared/Entities/Identity/UserIdentity.cs
+++ b/src/Skoruba.Duende.IdentityServer.Admin.EntityFramework.Shared/Entities/Identity/UserIdentity.cs
@@ -5,7 +5,7 @@ using Microsoft.AspNetCore.Identity;
 
 namespace Skoruba.Duende.IdentityServer.Admin.EntityFramework.Shared.Entities.Identity
 {
-	public class UserIdentity : IdentityUser
+	public class UserIdentity : IdentityUser, IUserWithDomain
 	{
 		public string UserDomain { get; set; }
 	}

--- a/src/Skoruba.Duende.IdentityServer.STS.Identity/Controllers/ManageController.cs
+++ b/src/Skoruba.Duende.IdentityServer.STS.Identity/Controllers/ManageController.cs
@@ -16,6 +16,7 @@ using Skoruba.Duende.IdentityServer.STS.Identity.Configuration.Interfaces;
 using Skoruba.Duende.IdentityServer.STS.Identity.Helpers;
 using Skoruba.Duende.IdentityServer.STS.Identity.Helpers.Localization;
 using Skoruba.Duende.IdentityServer.STS.Identity.ViewModels.Manage;
+using Skoruba.Duende.IdentityServer.Admin.EntityFramework.Shared.Entities.Identity;
 
 namespace Skoruba.Duende.IdentityServer.STS.Identity.Controllers
 {    
@@ -640,11 +641,11 @@ namespace Skoruba.Duende.IdentityServer.STS.Identity.Controllers
             var claims = await _userManager.GetClaimsAsync(user);
             var profile = OpenIdClaimHelpers.ExtractProfileInfo(claims);
 
-            var userIdentity = user as Admin.EntityFramework.Shared.Entities.Identity.UserIdentity;
+            var userWithDomain = user as IUserWithDomain;
 
             var model = new IndexViewModel
             {
-                UserDomain = userIdentity.UserDomain,
+                UserDomain = userWithDomain?.UserDomain,
                 Username = user.UserName,
                 Email = user.Email,
                 PhoneNumber = user.PhoneNumber,

--- a/src/Skoruba.Duende.IdentityServer.STS.Identity/Helpers/ApplicationSignInManager.cs
+++ b/src/Skoruba.Duende.IdentityServer.STS.Identity/Helpers/ApplicationSignInManager.cs
@@ -15,6 +15,7 @@ using Microsoft.AspNetCore.Identity;
 using Microsoft.Extensions.Logging;
 using Microsoft.Extensions.Options;
 using Skoruba.Duende.IdentityServer.STS.Identity.Configuration;
+using Skoruba.Duende.IdentityServer.Admin.EntityFramework.Shared.Entities.Identity;
 
 namespace Skoruba.Duende.IdentityServer.STS.Identity.Helpers
 {
@@ -82,19 +83,19 @@ namespace Skoruba.Duende.IdentityServer.STS.Identity.Helpers
         /// operation follows the regular flow in 
         /// <see cref="SignInManager{TUser}.CheckPasswordSignInAsync(TUser, string, bool)"/>.
         /// </remarks>
-        /// <param name="user">User identity. See <see cref="Admin.EntityFramework.Shared.Entities.Identity.UserIdentity"/>.</param>
+        /// <param name="user">User identity. See <see cref="IUserWithDomain"/>.</param>
         /// <param name="password">User password.</param>
         /// <param name="lockoutOnFailure">Whether or not to lockout the user account when password validation fails.</param>
         /// <returns><see cref="SignInResult"/></returns>
         public override async Task<SignInResult> CheckPasswordSignInAsync(TUser user, string password, bool lockoutOnFailure)
         {
-            // Try to cast the user identity to the custom UserIdentity class. If the cast fails, it means that the user identity does not have the UserDomain property, so we proceed with the regular password verification flow.
-            var userIdentity = user as Admin.EntityFramework.Shared.Entities.Identity.UserIdentity;
-            if (userIdentity == null)
+            // Try to cast the user identity to the custom IUserWithDomain interface. If the cast fails, it means that the user identity does not have the UserDomain property, so we proceed with the regular password verification flow.
+            var userWithDomain = user as IUserWithDomain;
+            if (userWithDomain == null)
                 return await base.CheckPasswordSignInAsync(user, password, lockoutOnFailure);
 
             // Try to get the user domain profile based on the UserDomain property of the user identity. If there is no user domain profile for the user's domain, it means that the user's domain is not registered to access the LDAP Web Api, so we proceed with the regular password verification flow.
-            var userDomainProfile = _ldapWebApiProvider.GetUserDomainProfile(userIdentity.UserDomain);
+            var userDomainProfile = _ldapWebApiProvider.GetUserDomainProfile(userWithDomain.UserDomain);
 
             // The user does not have an assigned domain or the user's domain is not registered to access the LDAP Web Api.
             if (userDomainProfile == null)
@@ -107,8 +108,8 @@ namespace Skoruba.Duende.IdentityServer.STS.Identity.Helpers
 
             var ldapAccountCredentials = new Bitai.LDAPHelper.DTO.LDAPDomainAccountCredential
             {
-                DomainName = userIdentity.UserDomain,
-                AccountName = userIdentity.UserName.Split('\\').Last(),
+                DomainName = userWithDomain.UserDomain,
+                AccountName = userWithDomain.UserName.Split('\\').Last(),
                 DomainAccountPassword = password
             };
 
@@ -206,13 +207,7 @@ namespace Skoruba.Duende.IdentityServer.STS.Identity.Helpers
             if (!await UserManager.IsLockedOutAsync(user))
                 return failedResult;
 
-            var lockedOutResult = CustomSignInResult.LockedOut;
-            lockedOutResult.HttpStatusCode = failedResult.HttpStatusCode;
-            lockedOutResult.HttpReasonPhrase = failedResult.HttpReasonPhrase;
-            lockedOutResult.HttpContentType = failedResult.HttpContentType;
-            lockedOutResult.HttpResponseContent = failedResult.HttpResponseContent;
-
-            return lockedOutResult;
+            return CustomSignInResult.LockedOut.WithMetadataFrom(failedResult);
         }
     }
 }

--- a/src/Skoruba.Duende.IdentityServer.STS.Identity/Helpers/ApplicationSignInManager.cs
+++ b/src/Skoruba.Duende.IdentityServer.STS.Identity/Helpers/ApplicationSignInManager.cs
@@ -88,13 +88,22 @@ namespace Skoruba.Duende.IdentityServer.STS.Identity.Helpers
         /// <returns><see cref="SignInResult"/></returns>
         public override async Task<SignInResult> CheckPasswordSignInAsync(TUser user, string password, bool lockoutOnFailure)
         {
+            // Try to cast the user identity to the custom UserIdentity class. If the cast fails, it means that the user identity does not have the UserDomain property, so we proceed with the regular password verification flow.
             var userIdentity = user as Admin.EntityFramework.Shared.Entities.Identity.UserIdentity;
+            if (userIdentity == null)
+                return await base.CheckPasswordSignInAsync(user, password, lockoutOnFailure);
 
+            // Try to get the user domain profile based on the UserDomain property of the user identity. If there is no user domain profile for the user's domain, it means that the user's domain is not registered to access the LDAP Web Api, so we proceed with the regular password verification flow.
             var userDomainProfile = _ldapWebApiProvider.GetUserDomainProfile(userIdentity.UserDomain);
 
             // The user does not have an assigned domain or the user's domain is not registered to access the LDAP Web Api.
             if (userDomainProfile == null)
+                // In this case, the password verification operation follows the regular flow in SignInManager<TUser>.CheckPasswordSignInAsync(TUser, string, bool).
                 return await base.CheckPasswordSignInAsync(user, password, lockoutOnFailure);
+            
+            var error = await PreSignInCheck(user);
+            if (error != null)
+                return error;
 
             var ldapAccountCredentials = new Bitai.LDAPHelper.DTO.LDAPDomainAccountCredential
             {
@@ -131,19 +140,18 @@ namespace Skoruba.Duende.IdentityServer.STS.Identity.Helpers
                 }
 
                 Logger.LogError("Login failed: DomainName:{0}, AccountName:{1}", ldapAccountCredentials.DomainName, ldapAccountCredentials.AccountName);
-                Logger.LogError($"Unsuccessful response when try to authenticate user credentials by LDAP Web Api. Response code: {(int)httpResponse.HttpStatusCode} ({httpResponse.ReasonPhrase}). Content Type: {httpResponse.ContentMediaType}");
+                Logger.LogError($"Failed to authenticate user credentials using the LDAP Web Api. Response Code: {(int)httpResponse.HttpStatusCode} ({httpResponse.ReasonPhrase}). Content Type: {httpResponse.ContentMediaType}");
                 Logger.LogError(responseContent);
                 #endregion
                 
-                CustomSignInResult _customResult;
-                
-                if (httpResponse.HttpStatusCode == System.Net.HttpStatusCode.Unauthorized)
-                    _customResult = CustomSignInResult.NotAllowed;
-                else
-                    _customResult = CustomSignInResult.Failed;
+                var _customResult = httpResponse.HttpStatusCode == System.Net.HttpStatusCode.Unauthorized
+                    ? CustomSignInResult.NotAllowed
+                    : CustomSignInResult.Failed;
 
                 _customResult.HttpStatusCode = (int)httpResponse.HttpStatusCode;
-                _customResult.HttpReasonPhrase = httpResponse.ReasonPhrase + middlewareException != null ? $"{middlewareException.Source}: {middlewareException.Message}" : string.Empty;
+                _customResult.HttpReasonPhrase = middlewareException != null
+                    ? $"{middlewareException.Source}: {middlewareException.Message}"
+                    : httpResponse.ReasonPhrase;
                 _customResult.HttpContentType = httpResponse.ContentMediaType.ToString();
                 _customResult.HttpResponseContent = responseContent;
 
@@ -153,18 +161,58 @@ namespace Skoruba.Duende.IdentityServer.STS.Identity.Helpers
             {
                 var accountAuthenticationStatus = ldapAuthenticationsWebApiClient.GetDTOFromResponse<Bitai.LDAPHelper.DTO.LDAPDomainAccountAuthenticationResult>(httpResponse);
 
-                CustomSignInResult _customResult;
-
                 if (accountAuthenticationStatus.IsAuthenticated)
-                    _customResult = CustomSignInResult.Success;
-                else
-                    _customResult = CustomSignInResult.NotAllowed;
+                {
+                    var successResult = CustomSignInResult.Success;
+                    successResult.HttpStatusCode = (int)httpResponse.HttpStatusCode;
+                    successResult.HttpReasonPhrase = accountAuthenticationStatus.OperationMessage;
 
-                _customResult.HttpStatusCode = (int)httpResponse.HttpStatusCode;
-                _customResult.HttpReasonPhrase = accountAuthenticationStatus.OperationMessage;
+                    return await ResetAccessFailedCountOnSuccessAsync(user, successResult);
+                }
 
-                return _customResult;
+                var failedResult = CustomSignInResult.NotAllowed;
+                failedResult.HttpStatusCode = (int)httpResponse.HttpStatusCode;
+                failedResult.HttpReasonPhrase = accountAuthenticationStatus.OperationMessage;
+
+                return await AccessFailedOnLdapRejectionAsync(user, lockoutOnFailure, failedResult);
             }
+        }
+
+        private async Task<SignInResult> ResetAccessFailedCountOnSuccessAsync(TUser user, CustomSignInResult successResult)
+        {
+            if (!UserManager.SupportsUserLockout)
+                return successResult;
+
+            var resetResult = await UserManager.ResetAccessFailedCountAsync(user);
+            if (resetResult.Succeeded)
+                return successResult;
+
+            Logger.LogWarning("LDAP login succeeded, but resetting the access failed count failed for user.");
+            return CustomSignInResult.Failed;
+        }
+
+        private async Task<SignInResult> AccessFailedOnLdapRejectionAsync(TUser user, bool lockoutOnFailure, CustomSignInResult failedResult)
+        {
+            if (!UserManager.SupportsUserLockout || !lockoutOnFailure)
+                return failedResult;
+
+            var incrementResult = await UserManager.AccessFailedAsync(user);
+            if (!incrementResult.Succeeded)
+            {
+                Logger.LogWarning("LDAP login failed, but incrementing the access failed count failed for user.");
+                return CustomSignInResult.Failed;
+            }
+
+            if (!await UserManager.IsLockedOutAsync(user))
+                return failedResult;
+
+            var lockedOutResult = CustomSignInResult.LockedOut;
+            lockedOutResult.HttpStatusCode = failedResult.HttpStatusCode;
+            lockedOutResult.HttpReasonPhrase = failedResult.HttpReasonPhrase;
+            lockedOutResult.HttpContentType = failedResult.HttpContentType;
+            lockedOutResult.HttpResponseContent = failedResult.HttpResponseContent;
+
+            return lockedOutResult;
         }
     }
 }

--- a/src/Skoruba.Duende.IdentityServer.STS.Identity/Helpers/SignInResult.cs
+++ b/src/Skoruba.Duende.IdentityServer.STS.Identity/Helpers/SignInResult.cs
@@ -16,26 +16,17 @@
 
 
         #region Static members & methods
-        private static readonly CustomSignInResult _success = new CustomSignInResult { Succeeded = true };
-        private static readonly CustomSignInResult _failed = new CustomSignInResult();
-        private static readonly CustomSignInResult _lockedOut = new CustomSignInResult { IsLockedOut = true };
-        private static readonly CustomSignInResult _notAllowed = new CustomSignInResult { IsNotAllowed = true };
-        private static readonly CustomSignInResult _twoFactorRequired = new CustomSignInResult { RequiresTwoFactor = true };
-
-
-
-
         /// <summary>
         /// Returns a <see cref="SignInResult"/> that represents a successful sign-in.
         /// </summary>
         /// <returns>A <see cref="SignInResult"/> that represents a successful sign-in.</returns>
-        public new static CustomSignInResult Success => _success;
+        public new static CustomSignInResult Success => new CustomSignInResult { Succeeded = true };
 
         /// <summary>
         /// Returns a <see cref="SignInResult"/> that represents a failed sign-in.
         /// </summary>
         /// <returns>A <see cref="SignInResult"/> that represents a failed sign-in.</returns>
-        public new static CustomSignInResult Failed => _failed;
+        public new static CustomSignInResult Failed => new CustomSignInResult();
 
         /// <summary>
         /// Returns a <see cref="SignInResult"/> that represents a sign-in attempt that failed because
@@ -43,7 +34,7 @@
         /// </summary>
         /// <returns>A <see cref="SignInResult"/> that represents sign-in attempt that failed due to the
         /// user being locked out.</returns>
-        public new static CustomSignInResult LockedOut => _lockedOut;
+        public new static CustomSignInResult LockedOut => new CustomSignInResult { IsLockedOut = true };
 
         /// <summary>
         /// Returns a <see cref="SignInResult"/> that represents a sign-in attempt that failed because
@@ -51,7 +42,7 @@
         /// </summary>
         /// <returns>A <see cref="SignInResult"/> that represents sign-in attempt that failed due to the
         /// user is not allowed to sign-in.</returns>
-        public new static CustomSignInResult NotAllowed => _notAllowed;
+        public new static CustomSignInResult NotAllowed => new CustomSignInResult { IsNotAllowed = true };
 
         /// <summary>
         /// Returns a <see cref="SignInResult"/> that represents a sign-in attempt that needs two-factor
@@ -59,7 +50,7 @@
         /// </summary>
         /// <returns>A <see cref="SignInResult"/> that represents sign-in attempt that needs two-factor
         /// authentication.</returns>
-        public new static CustomSignInResult TwoFactorRequired => _twoFactorRequired;
+        public new static CustomSignInResult TwoFactorRequired => new CustomSignInResult { RequiresTwoFactor = true };
         #endregion
     }
 }

--- a/src/Skoruba.Duende.IdentityServer.STS.Identity/Helpers/SignInResult.cs
+++ b/src/Skoruba.Duende.IdentityServer.STS.Identity/Helpers/SignInResult.cs
@@ -12,6 +12,16 @@
 
         public CustomSignInResult(): base() { }
 
+        public CustomSignInResult WithMetadataFrom(CustomSignInResult other)
+        {
+            HttpStatusCode = other.HttpStatusCode;
+            HttpReasonPhrase = other.HttpReasonPhrase;
+            HttpContentType = other.HttpContentType;
+            HttpResponseContent = other.HttpResponseContent;
+
+            return this;
+        }
+
 
 
 


### PR DESCRIPTION
Fix LDAP users lockout and fail counters.

## Summary by Sourcery

Ensure LDAP-backed sign-in participates correctly in Identity lockout and access-failed counting while generalizing domain-aware user handling.

Bug Fixes:
- Fix LDAP authentication flow so successful LDAP sign-ins reset access-failed counters and rejected sign-ins increment failure counts and trigger lockout when configured.
- Correct CustomSignInResult metadata handling so each result instance carries its own HTTP status and reason information without shared state issues.
- Avoid invalid casts by introducing and using an IUserWithDomain interface for domain-aware users in sign-in and manage flows.