### PR TITLE
Update LDAPWebApi.Clients reference.

### DIFF
--- a/src/Skoruba.Duende.IdentityServer.STS.Identity/Helpers/ApplicationSignInManager.cs
+++ b/src/Skoruba.Duende.IdentityServer.STS.Identity/Helpers/ApplicationSignInManager.cs
@@ -114,7 +114,7 @@ namespace Skoruba.Duende.IdentityServer.STS.Identity.Helpers
             };
 
             var ldapAuthenticationsWebApiClient = userDomainProfile.GetLdapAuthenticationsWebApiClient();
-            var httpResponse = await ldapAuthenticationsWebApiClient.AuthenticateAsync(ldapAccountCredentials);
+            var httpResponse = await ldapAuthenticationsWebApiClient.AuthenticateAsync(ldapAccountCredentials, $"{nameof(ApplicationSignInManager<TUser>)}.{nameof(CheckPasswordSignInAsync)}", userDomainProfile.LdapWebApiProfile.ClientCredentialRequired);
             if (!httpResponse.IsSuccessResponse)
             {
                 #region Write event log

--- a/src/Skoruba.Duende.IdentityServer.STS.Identity/Skoruba.Duende.IdentityServer.STS.Identity.csproj
+++ b/src/Skoruba.Duende.IdentityServer.STS.Identity/Skoruba.Duende.IdentityServer.STS.Identity.csproj
@@ -23,7 +23,7 @@
 		<PackageReference Include="AspNetCore.HealthChecks.SqlServer" Version="8.0.2" />
 		<PackageReference Include="AspNetCore.HealthChecks.UI" Version="8.0.2" />
 		<PackageReference Include="AspNetCore.HealthChecks.UI.Client" Version="8.0.1" />
-		<PackageReference Include="Bitai.LDAPWebApi.Clients" Version="8.0.1" />
+		<PackageReference Include="Bitai.LDAPWebApi.Clients" Version="8.6.0" />
 		<PackageReference Include="Microsoft.AspNetCore.DataProtection.EntityFrameworkCore" Version="8.0.8" />
 		<PackageReference Include="Microsoft.AspNetCore.Diagnostics.EntityFrameworkCore" Version="8.0.8" />
 		<PackageReference Include="Microsoft.AspNetCore.Identity.EntityFrameworkCore" Version="8.0.8" />
@@ -38,8 +38,8 @@
 		<PackageReference Include="Microsoft.Identity.Web" Version="3.2.0" />
 		<PackageReference Include="Microsoft.VisualStudio.Azure.Containers.Tools.Targets" Version="1.21.0" />
 		<PackageReference Include="Microsoft.AspNetCore.Identity.UI" Version="8.0.8" />
-        <PackageReference Include="Duende.IdentityServer.AspNetIdentity" Version="7.0.7" />
-        <PackageReference Include="Duende.IdentityServer.EntityFramework" Version="7.0.7" />
+        <PackageReference Include="Duende.IdentityServer.AspNetIdentity" Version="7.4.7" />
+        <PackageReference Include="Duende.IdentityServer.EntityFramework" Version="7.4.7" />
 		<PackageReference Include="Serilog" Version="4.0.1" />
 		<PackageReference Include="Serilog.Enrichers.Environment" Version="3.0.1" />
 		<PackageReference Include="Serilog.Enrichers.Thread" Version="4.0.0" />


### PR DESCRIPTION
Fix LDAP authentication without client credentials bug.

## Summary by Sourcery

Bug Fixes:
- Fix LDAP authentication failures when client credentials are not required by passing the appropriate flag to the LDAP Web API.