### PR TITLE
Fix Duende.IdentityServer.AspNetIdentity reference.

### DIFF
--- a/src/Skoruba.Duende.IdentityServer.STS.Identity/Skoruba.Duende.IdentityServer.STS.Identity.csproj
+++ b/src/Skoruba.Duende.IdentityServer.STS.Identity/Skoruba.Duende.IdentityServer.STS.Identity.csproj
@@ -38,8 +38,8 @@
 		<PackageReference Include="Microsoft.Identity.Web" Version="3.2.0" />
 		<PackageReference Include="Microsoft.VisualStudio.Azure.Containers.Tools.Targets" Version="1.21.0" />
 		<PackageReference Include="Microsoft.AspNetCore.Identity.UI" Version="8.0.8" />
-        <PackageReference Include="Duende.IdentityServer.AspNetIdentity" Version="7.4.7" />
-        <PackageReference Include="Duende.IdentityServer.EntityFramework" Version="7.4.7" />
+        <PackageReference Include="Duende.IdentityServer.AspNetIdentity" Version="7.0.7" />
+        <PackageReference Include="Duende.IdentityServer.EntityFramework" Version="7.0.7" />
 		<PackageReference Include="Serilog" Version="4.0.1" />
 		<PackageReference Include="Serilog.Enrichers.Environment" Version="3.0.1" />
 		<PackageReference Include="Serilog.Enrichers.Thread" Version="4.0.0" />


### PR DESCRIPTION
Fix Duende.IdentityServer.AspNetIdentity reference.

## Summary by Sourcery

Build:
- Fix an incorrect or outdated Duende.IdentityServer.AspNetIdentity reference in the STS Identity .csproj file.